### PR TITLE
Meow mj patch 1

### DIFF
--- a/src/CGRANode.cpp
+++ b/src/CGRANode.cpp
@@ -194,10 +194,10 @@ bool CGRANode::canSupport(DFGNode* t_opt) {
       (t_opt->isAdd()        and !canAdd()) or 
       (t_opt->isMul()        and !canMul()) or 
       (t_opt->isPhi()        and !canPhi()) or 
-   // (t_opt->isSel()        and !canSel()) or 
-   // (t_opt->isMAC()        and !canMAC()) or 
-   // (t_opt->isLogic()      and !canLogic()) or 
-   // (t opt->isBr()         and !canBr()) or 
+      (t_opt->isSel()        and !canSel()) or 
+      (t_opt->isMAC()        and !canMAC()) or 
+      (t_opt->isLogic()      and !canLogic()) or 
+      (t opt->isBranch()     and !canBr()) or 
       (t_opt->isCmp()        and !canCmp()) ){ 
     return false;
   }

--- a/src/CGRANode.cpp
+++ b/src/CGRANode.cpp
@@ -190,7 +190,15 @@ bool CGRANode::canSupport(DFGNode* t_opt) {
       (t_opt->isReturn()     and !canReturn()) or
       (t_opt->isCall()       and !canCall())  or
       (t_opt->isVectorized() and !supportVectorization()) or
-      (t_opt->hasCombined()  and !supportComplex() )){
+      (t_opt->hasCombined()  and !supportComplex()) or
+      (t_opt->isAdd()        and !canAdd()) or 
+      (t_opt->isMul()        and !canMul()) or 
+      (t_opt->isPhi()        and !canPhi()) or 
+   // (t_opt->isSel()        and !canSel()) or 
+   // (t_opt->isMAC()        and !canMAC()) or 
+   // (t_opt->isLogic()      and !canLogic()) or 
+   // (t opt->isBr()         and !canBr()) or 
+      (t_opt->isCmp()        and !canCmp()) ){ 
     return false;
   }
   return true;

--- a/src/CGRANode.cpp
+++ b/src/CGRANode.cpp
@@ -197,7 +197,7 @@ bool CGRANode::canSupport(DFGNode* t_opt) {
       (t_opt->isSel()        and !canSel()) or 
       (t_opt->isMAC()        and !canMAC()) or 
       (t_opt->isLogic()      and !canLogic()) or 
-      (t opt->isBranch()     and !canBr()) or 
+      (t_opt->isBranch()     and !canBr()) or 
       (t_opt->isCmp()        and !canCmp()) ){ 
     return false;
   }

--- a/src/DFGNode.cpp
+++ b/src/DFGNode.cpp
@@ -216,6 +216,30 @@ bool DFGNode::isGetptr() {
   return false;
 }
 
+bool DFGNode::isSel() {
+  if (m_opcodeName.compare("select") == 0)
+    return true;
+  return false;
+}
+
+bool DFGNode::isMAC() {
+  if ((m_opcodeName.compare("getelementptr") == 0 or
+      m_opcodeName.compare("add") == 0  or
+      m_opcodeName.compare("fadd") == 0 or
+      m_opcodeName.compare("sub") == 0  or
+      m_opcodeName.compare("fsub") == 0) &&
+      (m_opcodeName.compare("fmul") == 0 or
+      m_opcodeName.compare("mul") == 0))
+    return true;
+  return false;
+}
+
+bool DFGNode::isLogic() {
+  if (m_opcodeName.compare("or") == 0 or m_opcodeName.compare("and") == 0)
+    return true;
+  return false;
+}
+
 bool DFGNode::hasCombined() {
   return m_combined;
 }

--- a/src/DFGNode.h
+++ b/src/DFGNode.h
@@ -82,6 +82,9 @@ class DFGNode {
     bool isCmp();
     bool isBitcast();
     bool isGetptr();
+    bool isSel();
+    bool isMAC();
+    bool isLogic();
     bool isOpt(string);
     bool isVectorized();
     bool hasCombined();


### PR DESCRIPTION
1.  isSel() etc. are defined in DFGNode.cpp so I can include them in canSupport(). With fixed canSupport(), the heterogeneity of CGRA is working now.
2.  cgra-flow docker with GUI does not support heterogeneity, if supported, it stays the same setup with CGRA-Mapper's libmapperPass.so. 