### PR TITLE
Revert filename paramCGRA.json for cgra design

### DIFF
--- a/src/CGRA.cpp
+++ b/src/CGRA.cpp
@@ -59,7 +59,7 @@ CGRA::CGRA(int t_rows, int t_columns, bool t_diagonalVectorization,
       }
     }
 
-    ifstream paramCGRA("./param.json");
+    ifstream paramCGRA("./paramCGRA.json");
     if (!paramCGRA.good()) {
       cout<<"Parameterizable CGRA design/mapping requires paramCGRA.json"<<endl;
       return;


### PR DESCRIPTION
Guess this was a misoperation to change filename from paramCGRA.json to param.json in commit: https://github.com/yuqisun/CGRA-Mapper/commit/2cfc7f77732714c44688afeda64c81de00a524e7#diff-f1e96b93e3cc47051a6c9e2300ba678e86c648ddff8b913c1e804f8216d8d99dR62.

It caused issue when generate DFG. More detail: https://github.com/tancheng/CGRA-Flow/discussions/67#discussioncomment-13631268