### PR TITLE
perf: optimize CGRANode::isOccupied with O(1) periodic lookup (~7.5x speedup)

### DIFF
--- a/src/CGRANode.cpp
+++ b/src/CGRANode.cpp
@@ -377,6 +377,10 @@ bool CGRANode::canOccupy(DFGNode* t_opt, int t_cycle, int t_II) {
 }
 
 bool CGRANode::isOccupied(int t_cycle, int t_II) {
+  // Optimization: setDFGNode() has already materialized the DFG node mapping 
+  // across all cycles with II interval (populating cycle, cycle+II, etc.).
+  // Therefore, checking the specific canonical cycle here is sufficient 
+  // and equivalent to checking the entire loop.
   for (pair<DFGNode*, int> p: *(m_dfgNodesWithOccupyStatus[t_II+(t_cycle)%t_II])){
     // If DVFS is supported, the entire tile is occupied before the current multi-cycle operation
     // completes. Otherwise, the next operation can start before the current one completes.

--- a/src/CGRANode.cpp
+++ b/src/CGRANode.cpp
@@ -381,7 +381,7 @@ bool CGRANode::isOccupied(int t_cycle, int t_II) {
   // across all cycles with II interval (populating cycle, cycle+II, etc.).
   // Therefore, checking the specific canonical cycle here is sufficient 
   // and equivalent to checking the entire loop.
-  for (pair<DFGNode*, int> p: *(m_dfgNodesWithOccupyStatus[t_II+(t_cycle)%t_II])){
+  for (pair<DFGNode*, int> p: *(m_dfgNodesWithOccupyStatus[t_II + (t_cycle % t_II)])){
     // If DVFS is supported, the entire tile is occupied before the current multi-cycle operation
     // completes. Otherwise, the next operation can start before the current one completes.
     if (p.second == START_PIPE_OCCUPY or p.second == SINGLE_OCCUPY or m_supportDVFS) {

--- a/src/CGRANode.cpp
+++ b/src/CGRANode.cpp
@@ -377,13 +377,11 @@ bool CGRANode::canOccupy(DFGNode* t_opt, int t_cycle, int t_II) {
 }
 
 bool CGRANode::isOccupied(int t_cycle, int t_II) {
-  for (int cycle=t_cycle; cycle<m_cycleBoundary; cycle+=t_II) {
-    for (pair<DFGNode*, int> p: *(m_dfgNodesWithOccupyStatus[cycle])) {
-      // If DVFS is supported, the entire tile is occupied before the current multi-cycle operation
-      // completes. Otherwise, the next operation can start before the current one completes.
-      if (p.second == START_PIPE_OCCUPY or p.second == SINGLE_OCCUPY or m_supportDVFS) {
-        return true;
-      }
+  for (pair<DFGNode*, int> p: *(m_dfgNodesWithOccupyStatus[t_II+(t_cycle)%t_II])){
+    // If DVFS is supported, the entire tile is occupied before the current multi-cycle operation
+    // completes. Otherwise, the next operation can start before the current one completes.
+    if (p.second == START_PIPE_OCCUPY or p.second == SINGLE_OCCUPY or m_supportDVFS) {
+      return true;
     }
   }
   return false;


### PR DESCRIPTION
Profiling the mapper using perf (with OpenMP disabled to isolate algorithmic costs) revealed that CGRANode::isOccupied consumes approximately 70-80% of the total execution time.

I replaced the O(N) linear loop with an O(1) direct index lookup
This change maintains bit-perfect consistency with the original logic but eliminates the loop overhead.

To demonstrate scalability, I tested the fir kernel with an enlarged CGRA configuration (rows=16, cols=16 in param.json):

| Metric | Original | This PR |
| :--- | :--- | :--- |
| Time | ~197s | ~26s |
| Speedup | - | ~7.5x |
| Result (II) | 16 | 16 |

After removing this bottleneck, the overhead of OpenMP thread management has become relatively significant compared to the reduced computation time. We might need to reconsider the necessity of the current OpenMP strategy in future optimizations